### PR TITLE
Remove the use of pwgen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+KEY=$(shell strings /dev/urandom | grep -o '[[:alnum:]]' | head -n 64 | tr -d '\n';)
+
 default: lint test
 
 .env:
-	@echo SECRET_KEY=`pwgen 64 1` >> $@
+	@echo SECRET_KEY="$(KEY)" >> $@
 
 install: .env
 	pip install -r requirements.txt


### PR DESCRIPTION
It isn't always installed and it's easy enough to generate a sufficiently random string without it. Fixes #3.
