### PR TITLE
Check for .env file and load it if available

### DIFF
--- a/project_name/wsgi.py
+++ b/project_name/wsgi.py
@@ -15,7 +15,9 @@ from django.core.wsgi import get_wsgi_application
 from whitenoise.django import DjangoWhiteNoise
 
 
-dotenv.read_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__), '.env')))
+env = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env')
+if os.path.exists(env):
+    dotenv.read_dotenv(env)
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{ project_name }}.settings')
 
 application = DjangoWhiteNoise(get_wsgi_application())


### PR DESCRIPTION
Fixes #2. Seems like a good middle ground. If the environment variables are populated by some other means then the file doesn't need to exist.
